### PR TITLE
Use generic instead of associated type

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -2,5 +2,5 @@ edition = "2018"
 unstable_features = true
 format_code_in_doc_comments = true
 reorder_imports = true
-merge_imports = true
+imports_granularity= "Crate"
 group_imports = "StdExternalCrate"

--- a/src/codec/bytes.rs
+++ b/src/codec/bytes.rs
@@ -31,11 +31,10 @@ use crate::{Decoder, Encoder};
 #[derive(Debug, Clone, Copy)]
 pub struct BytesCodec {}
 
-impl Encoder for BytesCodec {
-    type Item = Bytes;
+impl Encoder<Bytes> for BytesCodec {
     type Error = Error;
 
-    fn encode(&mut self, src: Self::Item, dst: &mut BytesMut) -> Result<(), Self::Error> {
+    fn encode(&mut self, src: Bytes, dst: &mut BytesMut) -> Result<(), Self::Error> {
         dst.extend_from_slice(&src);
         Ok(())
     }

--- a/src/codec/lines.rs
+++ b/src/codec/lines.rs
@@ -22,11 +22,10 @@ use crate::{Decoder, Encoder};
 #[derive(Debug, Clone, Copy)]
 pub struct LinesCodec {}
 
-impl Encoder for LinesCodec {
-    type Item = String;
+impl Encoder<String> for LinesCodec {
     type Error = Error;
 
-    fn encode(&mut self, item: Self::Item, dst: &mut BytesMut) -> Result<(), Self::Error> {
+    fn encode(&mut self, item: String, dst: &mut BytesMut) -> Result<(), Self::Error> {
         dst.reserve(item.len());
         dst.put(item.as_bytes());
         Ok(())

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -5,21 +5,18 @@ use bytes::BytesMut;
 use super::fuse::Fuse;
 
 /// Encoding of messages as bytes, for use with `FramedWrite`.
-pub trait Encoder {
-    /// The type of items consumed by `encode`
-    type Item;
+pub trait Encoder<Item> {
     /// The type of encoding errors.
     type Error: From<Error>;
 
     /// Encodes an item into the `BytesMut` provided by dst.
-    fn encode(&mut self, item: Self::Item, dst: &mut BytesMut) -> Result<(), Self::Error>;
+    fn encode(&mut self, item: Item, dst: &mut BytesMut) -> Result<(), Self::Error>;
 }
 
-impl<T, U: Encoder> Encoder for Fuse<T, U> {
-    type Item = U::Item;
+impl<T, Item, U: Encoder<Item>> Encoder<Item> for Fuse<T, U> {
     type Error = U::Error;
 
-    fn encode(&mut self, item: Self::Item, dst: &mut BytesMut) -> Result<(), Self::Error> {
+    fn encode(&mut self, item: Item, dst: &mut BytesMut) -> Result<(), Self::Error> {
         self.codec.encode(item, dst)
     }
 }

--- a/src/framed.rs
+++ b/src/framed.rs
@@ -54,10 +54,7 @@ impl<T, U> DerefMut for Framed<T, U> {
     }
 }
 
-impl<T, U> Framed<T, U>
-where
-    U: Decoder + Encoder,
-{
+impl<T, U> Framed<T, U> {
     /// Creates a new `Framed` transport with the given codec.
     /// A codec is a type which implements `Decoder` and `Encoder`.
     pub fn new(inner: T, codec: U) -> Self {
@@ -117,14 +114,14 @@ where
     }
 }
 
-impl<T, U> IterSink<U::Item> for Framed<T, U>
+impl<T, U, I> IterSink<I> for Framed<T, U>
 where
     T: Write,
-    U: Encoder,
+    U: Encoder<I>,
 {
     type Error = U::Error;
 
-    fn start_send(&mut self, item: U::Item) -> Result<(), Self::Error> {
+    fn start_send(&mut self, item: I) -> Result<(), Self::Error> {
         self.inner.start_send(item)
     }
 
@@ -165,10 +162,10 @@ mod if_async {
         }
     }
 
-    impl<T, U> Sink<U::Item> for Framed<T, U>
+    impl<T, U, I> Sink<I> for Framed<T, U>
     where
         T: AsyncWrite + Unpin,
-        U: Encoder,
+        U: Encoder<I>,
     {
         type Error = U::Error;
 
@@ -176,7 +173,7 @@ mod if_async {
             self.project().inner.poll_ready(cx)
         }
 
-        fn start_send(self: Pin<&mut Self>, item: U::Item) -> Result<(), Self::Error> {
+        fn start_send(self: Pin<&mut Self>, item: I) -> Result<(), Self::Error> {
             self.project().inner.start_send(item)
         }
 


### PR DESCRIPTION
Use a generic param instead of associated type for Encoders. That way we can use the same encoder for `SBP`/`&SBP`/`Arc<SBP>` etc